### PR TITLE
Fix typo in ColorSliderControl

### DIFF
--- a/FlexColorPicker/Classes/Controls/ColorSliderControl.swift
+++ b/FlexColorPicker/Classes/Controls/ColorSliderControl.swift
@@ -126,7 +126,7 @@ open class ColorSliderControl: ColorControlWithThumbView {
 extension ColorSliderControl {
     /// When `true` the slider's thumb will automatically darken its border when selected color is too bright to be contrast enought with white border.
     @IBInspectable
-    public var autoDaken: Bool {
+    public var autoDarken: Bool {
         get {
             return thumbView.autoDarken
         }

--- a/FlexColorPickerDemo/Classes/Main.storyboard
+++ b/FlexColorPickerDemo/Classes/Main.storyboard
@@ -593,7 +593,7 @@
                                                     <userDefinedRuntimeAttribute type="color" keyPath="selectedColor">
                                                         <color key="value" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="autoDaken" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="autoDarken" value="NO"/>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                         </subviews>


### PR DESCRIPTION
Fix `autoDaken` to `autoDarken` as I believe was the intended naming