### PR TITLE
fix(warnings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap

--- a/FlexColorPicker/Classes/ColorPickerControllerProtocol.swift
+++ b/FlexColorPicker/Classes/ColorPickerControllerProtocol.swift
@@ -29,7 +29,7 @@
 import UIKit
 
 /// Protocol implemented by controllers that connect and synchronize *color controls* (`UIView`s, see protocol `ColorControl`) used to pick color. These can be view controllers that also display those *color controls*.
-public protocol ColorPickerControllerProtocol: class {
+public protocol ColorPickerControllerProtocol: AnyObject {
     /// Delegate notified when selected color is changed or when user confirms currently selected color.
     var delegate: ColorPickerDelegate? { get set }
     /// Currently selected color.

--- a/FlexColorPicker/Classes/ColorPickerDelegate.swift
+++ b/FlexColorPicker/Classes/ColorPickerDelegate.swift
@@ -32,7 +32,7 @@ import UIKit
 ///
 /// **See also:**
 /// [DefaultColorPickerViewController](https://github.com/RastislavMirek/FlexColorPicker/blob/master/FlexColorPicker/Classes/DefaultColorPickerViewController.swift), [ColorPickerController](https://github.com/RastislavMirek/FlexColorPicker/blob/master/FlexColorPicker/Classes/ColorPickerController.swift)
-public protocol ColorPickerDelegate: class {
+public protocol ColorPickerDelegate: AnyObject {
 
     /// Called when a user changes color picker's current selected color.
     ///

--- a/FlexColorPicker/Classes/ControlDelegates/ColorPaletteDelegate.swift
+++ b/FlexColorPicker/Classes/ControlDelegates/ColorPaletteDelegate.swift
@@ -28,7 +28,7 @@
 
 import UIKit
 
-public protocol ColorPaletteDelegate: class {
+public protocol ColorPaletteDelegate: AnyObject {
     var size: CGSize { get set }
     func modifiedColor(from color: HSBColor, with point: CGPoint) -> HSBColor
     func foregroundImage() -> UIImage

--- a/FlexColorPicker/Classes/Controls/AdjustedHitBoxColorControl.swift
+++ b/FlexColorPicker/Classes/Controls/AdjustedHitBoxColorControl.swift
@@ -46,7 +46,11 @@ open class AdjustedHitBoxColorControl: AbstractColorControl {
 
     /// The alighnment rectangle of the color control in its own coordinate system.
     public var contentBounds: CGRect {
-        layoutIfNeeded()
+        if #available(iOS 15, *) {
+            /// Do nothing here
+        } else {
+            layoutIfNeeded()
+        }
         return contentView.frame
     }
 

--- a/FlexColorPicker/Classes/Controls/ColorControl.swift
+++ b/FlexColorPicker/Classes/Controls/ColorControl.swift
@@ -35,7 +35,7 @@ import UIKit
 /// *Color control* sends `UIControlEvents.valueChanged` events to registered targets when its value (`selectedHSBColor`) changes as consequence of user interaction with the control. A *color control* can also send `UIControlEvents.primaryActionTriggered` when user takes action to confirm current selected color as final.
 ///
 /// A *color control* should be usable as standalone component but is usually used together with other *color controls* managed and synchronized by instance of `ColorPickerController`.
-public protocol ColorControl: class {
+public protocol ColorControl: AnyObject {
     /// Override this and return `false` if you do not want `UIControlEvents.primaryActionTriggered` events sent by the color control to be considered confirmation of color selection.
     static var canConfirmColor: Bool { get }
     /// The value of this color control. Represents current selected color. Use `setSelectedHSBColor(_: isInteractive:)` to set value of this property.

--- a/FlexColorPicker/Classes/Controls/ColorPaletteControl.swift
+++ b/FlexColorPicker/Classes/Controls/ColorPaletteControl.swift
@@ -86,7 +86,11 @@ open class ColorPaletteControl: ColorControlWithThumbView {
     ///
     /// - Parameter interactive:  Whether the change originated from user interaction or is programatic. This can be used to determine if certain animations should be played.
     open func updatePaletteImagesAndThumb(isInteractive interactive: Bool) {
-        layoutIfNeeded() //force subviews layout to update their bounds - bounds of subviews are not automatically updated
+        if #available(iOS 15, *) {
+            /// Do nothing here
+        } else {
+            layoutIfNeeded() //force subviews layout to update their bounds - bounds of subviews are not automatically updated
+        }
         paletteDelegate.size = foregroundImageView.bounds.size //cannot use self.bounds as that is extended compared to foregroundImageView.bounds when AdjustedHitBoxColorControl.hitBoxInsets are non-zero
         foregroundImageView.image = paletteDelegate.foregroundImage()
         backgroundImageView.image = paletteDelegate.backgroundImage()

--- a/FlexColorPicker/Classes/Controls/ColorSliderControl.swift
+++ b/FlexColorPicker/Classes/Controls/ColorSliderControl.swift
@@ -113,7 +113,11 @@ open class ColorSliderControl: ColorControlWithThumbView {
     ///
     /// - Parameter interactive:  Whether the change originated from user interaction or is programatic. This can be used to determine if certain animations should be played.
     open func updateThumbAndGradient(isInteractive interactive: Bool) {
-        layoutIfNeeded() //ensure that subview bounds are updated as we are working with contentView.bounds.midY
+        if #available(iOS 15, *) {
+            /// Do nothing here
+        } else {
+            layoutIfNeeded() //force subviews layout to update their bounds - bounds of subviews are not automatically updated
+        }
         let (value, gradientStart, gradientEnd) = sliderDelegate.valueAndGradient(for: selectedHSBColor)
         let gradientLength = contentBounds.width - thumbView.colorIdicatorRadius * 2 //cannot use self.bounds as that is extended compared to foregroundImageView.bounds when AdjustedHitBoxColorControl.hitBoxInsets are non-zero
         thumbView.frame = CGRect(center: CGPoint(x: thumbView.colorIdicatorRadius + gradientLength * min(max(0, value), 1), y: contentView.bounds.midY), size: thumbView.intrinsicContentSize)

--- a/FlexColorPicker/Classes/Utilities/LimitedGestureViewDelegate.swift
+++ b/FlexColorPicker/Classes/Utilities/LimitedGestureViewDelegate.swift
@@ -28,6 +28,6 @@
 
 import UIKit
 
-public protocol LimitedGestureViewDelegate: class {
+public protocol LimitedGestureViewDelegate: AnyObject {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool
 }

--- a/FlexColorPicker/Classes/Views/ColorControlContentView.swift
+++ b/FlexColorPicker/Classes/Views/ColorControlContentView.swift
@@ -28,7 +28,7 @@
 
 import UIKit
 
-protocol ColorControlContentViewDelegate: class {
+protocol ColorControlContentViewDelegate: AnyObject {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -32,25 +32,22 @@ import PackageDescription
 let package = Package(
     name: "FlexColorPicker",
     platforms: [
-        SupportedPlatform.iOS(.v9),
+        .iOS(.v9),
     ],
     products: [
-        Product.library(name: "FlexColorPicker", targets: ["FlexColorPicker"]),
+        .library(name: "FlexColorPicker", targets: ["FlexColorPicker"]),
 //        Product.executable(name: "FlexColorPickerDemo", targets: ["FlexColorPickerDemo"]),
     ],
-    dependencies: [],
     targets: [
-        PackageDescription.Target.target(
+        .target(
             name: "FlexColorPicker",
             dependencies: [],
-            path: "FlexColorPicker/Classes",
-            exclude: ["../../FlexColorPicker.podspec", "FlexColorPicker.podspec", "../GifsAndScreenshots"]
+            path: "FlexColorPicker/Classes"
         ),
 //        PackageDescription.Target.target(
 //            name: "FlexColorPickerDemo",
 //            dependencies: ["FlexColorPicker"],
-//            path: "FlexColorPickerDemo/Classes",
-//            exclude: ["../../FlexColorPicker.podspec", "FlexColorPicker.podspec"]
+//            path: "FlexColorPickerDemo/Classes"
 //        )
     ]
 )


### PR DESCRIPTION
- Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
- caused by missing files in target exclude, which is redundant
- added DS_Store to .gitignore